### PR TITLE
Deployment tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,7 @@ jobs:
 
   test:
     name: test-production
-    needs: deploy-production
+    needs: deploy
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 
 env:
+  APPLICATION_URL_PROD: https://dependabot.martincostello.com
   AZURE_WEBAPP_NAME: dependabothelper
   AZURE_WEBAPP_PACKAGE_PATH: ./artifacts/publish
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -20,7 +21,6 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   NUGET_XMLDOC_MODE: skip
-  WEBSITE_URL_PROD: https://dependabot.martincostello.com
 
 jobs:
   build:
@@ -89,7 +89,7 @@ jobs:
     concurrency: production_environment
     environment:
       name: production
-      url: ${{ env.WEBSITE_URL_PROD }}
+      url: ${{ env.APPLICATION_URL_PROD }}
 
     steps:
 
@@ -104,3 +104,46 @@ jobs:
       with:
         app-name: ${{ env.AZURE_WEBAPP_NAME }}
         publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE  }}
+
+  test:
+    name: test-production
+    needs: deploy-production
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v2
+
+    - name: Run end-to-end tests
+      shell: pwsh
+      run: dotnet test ./tests/DependabotHelper.EndToEndTests --configuration Release --output ./artifacts
+      env:
+        APPLICATION_URL: ${{ env.APPLICATION_URL_PROD }}
+
+    - name: Publish screenshots
+      uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: screenshots
+        path: ./artifacts/screenshots/*
+        if-no-files-found: ignore
+
+    - name: Publish traces
+      uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: traces
+        path: ./artifacts/traces/*
+        if-no-files-found: ignore
+
+    - name: Publish videos
+      uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: videos
+        path: ./artifacts/videos/*
+        if-no-files-found: ignore

--- a/DependabotHelper.sln
+++ b/DependabotHelper.sln
@@ -63,6 +63,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ISSUE_TEMPLATE", "ISSUE_TEM
 		.github\ISSUE_TEMPLATE\feature_request.md = .github\ISSUE_TEMPLATE\feature_request.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DependabotHelper.EndToEndTests", "tests\DependabotHelper.EndToEndTests\DependabotHelper.EndToEndTests.csproj", "{D3A273BE-65C1-45EA-A1F3-BBCC2E6F0282}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -77,6 +79,10 @@ Global
 		{43392602-CB9C-4CF1-95E2-8A3404B5F40E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43392602-CB9C-4CF1-95E2-8A3404B5F40E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43392602-CB9C-4CF1-95E2-8A3404B5F40E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3A273BE-65C1-45EA-A1F3-BBCC2E6F0282}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3A273BE-65C1-45EA-A1F3-BBCC2E6F0282}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3A273BE-65C1-45EA-A1F3-BBCC2E6F0282}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3A273BE-65C1-45EA-A1F3-BBCC2E6F0282}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -88,6 +94,7 @@ Global
 		{420A66E9-DD98-499A-8675-A1F1248C8D50} = {6BE67078-7233-42C0-80F9-CE4BFD2DCD6D}
 		{DCA9533A-97AA-45FB-8BED-6F81CE1962EC} = {2808D3E0-7B58-4A2A-95BE-8027C4ED9918}
 		{870BF5AC-0761-458C-B3DB-572420BC562B} = {6BE67078-7233-42C0-80F9-CE4BFD2DCD6D}
+		{D3A273BE-65C1-45EA-A1F3-BBCC2E6F0282} = {FD791692-13A5-47D7-ACEB-4B0B336B359D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2F443F99-DDBC-4E35-A6A9-E790CA137404}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,14 +40,6 @@
     <VersionSuffix Condition=" $(GITHUB_REF.StartsWith(`refs/tags/v`)) "></VersionSuffix>
     <FileVersion Condition=" '$(GITHUB_RUN_NUMBER)' != '' ">$(VersionPrefix).$(GITHUB_RUN_NUMBER)</FileVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
-    <CollectCoverage>true</CollectCoverage>
-    <CoverletOutput Condition=" '$(OutputPath)' != '' ">$(OutputPath)/</CoverletOutput>
-    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
-    <Exclude>[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
-    <Threshold></Threshold>
-  </PropertyGroup>
   <ItemGroup Condition=" '$(PackageIcon)' != '' ">
     <None Include="$(MSBuildThisFileDirectory)$(PackageIcon)" Pack="True" PackagePath="" />
   </ItemGroup>

--- a/build.ps1
+++ b/build.ps1
@@ -144,7 +144,8 @@ $publishProjects = @(
 )
 
 $testProjects = @(
-    (Join-Path $solutionPath "tests" "DependabotHelper.Tests" "DependabotHelper.Tests.csproj")
+    (Join-Path $solutionPath "tests" "DependabotHelper.Tests" "DependabotHelper.Tests.csproj"),
+    (Join-Path $solutionPath "tests" "DependabotHelper.EndToEndTests" "DependabotHelper.EndToEndTests.csproj")
 )
 
 Write-Host "Publishing solution..." -ForegroundColor Green

--- a/src/DependabotHelper/CustomHttpHeadersMiddleware.cs
+++ b/src/DependabotHelper/CustomHttpHeadersMiddleware.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DependabotHelper;
+
+public sealed class CustomHttpHeadersMiddleware
+{
+    private static readonly string ContentSecurityPolicy = string.Join(
+        ';',
+        new[]
+        {
+            "default-src 'self'",
+            "script-src 'self' cdn.jsdelivr.net cdnjs.cloudflare.com",
+            "script-src-elem 'self' cdn.jsdelivr.net cdnjs.cloudflare.com",
+            "style-src 'self' cdn.jsdelivr.net cdnjs.cloudflare.com use.fontawesome.com",
+            "img-src 'self' avatars.githubusercontent.com",
+            "font-src 'self' cdnjs.cloudflare.com use.fontawesome.com",
+            "connect-src 'self'",
+            "media-src 'none'",
+            "object-src 'none'",
+            "child-src 'self'",
+            "frame-ancestors 'none'",
+            "form-action 'self' github.com",
+            "block-all-mixed-content",
+            "base-uri 'self'",
+            "manifest-src 'self'",
+            "upgrade-insecure-requests",
+        });
+
+    private readonly RequestDelegate _next;
+
+    public CustomHttpHeadersMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public Task Invoke(HttpContext context, IWebHostEnvironment environment)
+    {
+        context.Response.OnStarting(() =>
+        {
+            context.Response.Headers.Remove("Server");
+            context.Response.Headers.Remove("X-Powered-By");
+
+            if (environment.IsProduction())
+            {
+                context.Response.Headers.Add("Content-Security-Policy", ContentSecurityPolicy);
+            }
+
+            if (context.Request.IsHttps)
+            {
+                context.Response.Headers.Add("Expect-CT", "max-age=1800");
+            }
+
+            context.Response.Headers.Add("Feature-Policy", "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'");
+            context.Response.Headers.Add("Permissions-Policy", "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()");
+            context.Response.Headers.Add("Referrer-Policy", "no-referrer-when-downgrade");
+            context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+            context.Response.Headers.Add("X-Download-Options", "noopen");
+
+            if (!context.Response.Headers.ContainsKey("X-Frame-Options"))
+            {
+                context.Response.Headers.Add("X-Frame-Options", "DENY");
+            }
+
+            context.Response.Headers.Add("X-Request-Id", context.TraceIdentifier);
+            context.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
+
+            return Task.CompletedTask;
+        });
+
+        return _next(context);
+    }
+}

--- a/src/DependabotHelper/Pages/Shared/Error.cshtml
+++ b/src/DependabotHelper/Pages/Shared/Error.cshtml
@@ -2,7 +2,7 @@
 @model ErrorModel
 @{
     ViewBag.Title = Model.Title;
-    string modifier = Model.IsClientError ? "primary" : "danger";
+    string modifier = Model.IsClientError ? "secondary" : "danger";
 }
 <h1 class="text-@modifier">@Model.Subtitle</h1>
 <h2 class="text-@modifier">@Model.Message</h2>

--- a/src/DependabotHelper/Program.cs
+++ b/src/DependabotHelper/Program.cs
@@ -37,6 +37,8 @@ if (!app.Environment.IsDevelopment())
     app.UseExceptionHandler("/error");
 }
 
+app.UseMiddleware<CustomHttpHeadersMiddleware>();
+
 app.UseStatusCodePagesWithReExecute("/error", "?id={0}");
 
 if (!app.Environment.IsDevelopment())

--- a/src/DependabotHelper/web.config
+++ b/src/DependabotHelper/web.config
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <httpErrors errorMode="Custom">
+      <remove statusCode="400" />
+      <remove statusCode="404" />
+      <remove statusCode="500" />
+      <remove statusCode="502" />
+      <error statusCode="400" responseMode="File" path="wwwroot\bad-request.html" />
+      <error statusCode="404" responseMode="File" path="wwwroot\not-found.html" />
+      <error statusCode="500" responseMode="File" path="wwwroot\error.html" />
+      <error statusCode="502" responseMode="File" path="wwwroot\error.html" />
+    </httpErrors>
+    <httpProtocol>
+      <customHeaders>
+        <remove name="X-Powered-By" />
+      </customHeaders>
+    </httpProtocol>
+    <security>
+      <requestFiltering removeServerHeader="true" />
+    </security>
+    <urlCompression doDynamicCompression="true" doStaticCompression="true" />
+    <aspNetCore disableStartUpErrorPage="true" />
+  </system.webServer>
+</configuration>

--- a/src/DependabotHelper/wwwroot/bad-request.html
+++ b/src/DependabotHelper/wwwroot/bad-request.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Not found - Dependabot Helper</title>
+    <meta http-equiv="cache-control" content="no-cache, no-store" />
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="application-name" content="Dependabot Helper" />
+    <meta name="author" content="Martin Costello" />
+    <meta name="copyright" content="&copy; Martin Costello 2022" />
+    <meta name="language" content="en" />
+    <meta name="keywords" content="dependabot,github" />
+    <meta name="referrer" content="no-referrer-when-downgrade" />
+    <meta name="robots" content="NOINDEX" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="/css/site.css" />
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <img src="/favicon.png" width="30" height="30" class="d-inline-block align-top" aria-hidden="true">
+                Dependabot Helper
+            </a>
+        </div>
+    </nav>
+    <main class="container body-content">
+        <h1 class="text-secondary">Bad request (HTTP 400)</h1>
+        <h2 class="text-secondary">The request was invalid.</h2>
+        <hr />
+        <footer>
+            <p>
+                &copy; 2022 - Martin Costello
+            </p>
+        </footer>
+    </main>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/DependabotHelper/wwwroot/error.html
+++ b/src/DependabotHelper/wwwroot/error.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Not found - Dependabot Helper</title>
+    <meta http-equiv="cache-control" content="no-cache, no-store" />
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="application-name" content="Dependabot Helper" />
+    <meta name="author" content="Martin Costello" />
+    <meta name="copyright" content="&copy; Martin Costello 2022" />
+    <meta name="language" content="en" />
+    <meta name="keywords" content="dependabot,github" />
+    <meta name="referrer" content="no-referrer-when-downgrade" />
+    <meta name="robots" content="NOINDEX" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="/css/site.css" />
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <img src="/favicon.png" width="30" height="30" class="d-inline-block align-top" aria-hidden="true">
+                Dependabot Helper
+            </a>
+        </div>
+    </nav>
+    <main class="container body-content">
+        <h1 class="text-danger">Error</h1>
+        <h2 class="text-danger">Sorry, something went wrong.</h2>
+        <hr />
+        <footer>
+            <p>
+                &copy; 2022 - Martin Costello
+            </p>
+        </footer>
+    </main>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/src/DependabotHelper/wwwroot/not-found.html
+++ b/src/DependabotHelper/wwwroot/not-found.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Not found - Dependabot Helper</title>
+    <meta http-equiv="cache-control" content="no-cache, no-store" />
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+    <meta http-equiv="pragma" content="no-cache" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="application-name" content="Dependabot Helper" />
+    <meta name="author" content="Martin Costello" />
+    <meta name="copyright" content="&copy; Martin Costello 2022" />
+    <meta name="language" content="en" />
+    <meta name="keywords" content="dependabot,github" />
+    <meta name="referrer" content="no-referrer-when-downgrade" />
+    <meta name="robots" content="NOINDEX" />
+    <meta name="theme-color" content="#ffffff" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="shortcut icon" type="image/x-icon" href="/favicon.png" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/css/bootstrap.min.css" integrity="sha384-zCbKRCUGaJDkqS1kPbPd7TveP5iyJE0EjAuZQTgFLD2ylzuqKfdKlfG/eSrtxUkn" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" integrity="sha512-9usAa10IRO0HhonpyAIVpjrylPvoDwiPUiKdWk5t3PyolY1cOd4DSE0Ga+ri4AuTroPR5aQvXU9xC6qOPnzFeg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="/css/site.css" />
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+        <div class="container">
+            <a class="navbar-brand" href="/">
+                <img src="/favicon.png" width="30" height="30" class="d-inline-block align-top" aria-hidden="true">
+                Dependabot Helper
+            </a>
+        </div>
+    </nav>
+    <main class="container body-content">
+        <h1 class="text-secondary">Page not found (HTTP 404)</h1>
+        <h2 class="text-secondary">The page you requested could not be found.</h2>
+        <hr />
+        <footer>
+            <p>
+                &copy; 2022 - Martin Costello
+            </p>
+        </footer>
+    </main>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.slim.min.js" integrity="sha512-6ORWJX/LrnSjBzwefdNUyLCMTIsGoNP6NftMy2UAm1JBm6PRZCO1d7OHBStWpVFZLO+RerTvqX/Z9mBFfCJZ4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-fQybjgWLrvvRgtW6bFlB7jaZrFsaBXjsOMm/tB9LTS58ONXgqbR9W8oWht/amnpF" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/tests/DependabotHelper.EndToEndTests/AppCollection.cs
+++ b/tests/DependabotHelper.EndToEndTests/AppCollection.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DependabotHelper;
+
+[CollectionDefinition(Name)]
+public sealed class AppCollection : ICollectionFixture<AppFixture>
+{
+    public const string Name = "Application collection";
+}

--- a/tests/DependabotHelper.EndToEndTests/AppFixture.cs
+++ b/tests/DependabotHelper.EndToEndTests/AppFixture.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Net.Http.Headers;
+
+namespace MartinCostello.DependabotHelper;
+
+public class AppFixture
+{
+    private const string ApplicationUrl = "APPLICATION_URL";
+
+    private readonly Uri? _serverAddress;
+
+    public AppFixture()
+    {
+        string url = Environment.GetEnvironmentVariable(ApplicationUrl) ?? string.Empty;
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out _serverAddress))
+        {
+            _serverAddress = null;
+        }
+    }
+
+    public Uri ServerAddress
+    {
+        get
+        {
+            Skip.If(_serverAddress is null, $"The {ApplicationUrl} environment variable is not set or is not a valid absolute URI.");
+            return _serverAddress!;
+        }
+    }
+
+    private static string Version => Environment.GetEnvironmentVariable("GITHUB_RUN_ID") ?? "0";
+
+    public HttpClient CreateClient()
+    {
+        var client = new HttpClient()
+        {
+            BaseAddress = ServerAddress,
+        };
+
+        client.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue(
+                "DependabotHelper.EndToEndTests", Version));
+
+        return client;
+    }
+}

--- a/tests/DependabotHelper.EndToEndTests/DependabotHelper.EndToEndTests.csproj
+++ b/tests/DependabotHelper.EndToEndTests/DependabotHelper.EndToEndTests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <NoWarn>$(NoWarn);CA1054;CA1707;CA1711;CA1812;CA2007;CA2234;SA1600</NoWarn>
+    <RootNamespace>MartinCostello.DependabotHelper</RootNamespace>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Playwright" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="Xunit.SkippableFact" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Shouldly" />
+    <Using Include="Xunit" />
+    <Using Include="Xunit.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/tests/DependabotHelper.EndToEndTests/EndToEndTest.cs
+++ b/tests/DependabotHelper.EndToEndTests/EndToEndTest.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+namespace MartinCostello.DependabotHelper;
+
+[Collection(AppCollection.Name)]
+[Trait("Category", "EndToEnd")]
+public abstract class EndToEndTest
+{
+    protected EndToEndTest(AppFixture fixture, ITestOutputHelper outputHelper)
+    {
+        Fixture = fixture;
+        OutputHelper = outputHelper;
+    }
+
+    protected AppFixture Fixture { get; }
+
+    protected ITestOutputHelper OutputHelper { get; }
+
+    protected Uri ServerAddress => Fixture.ServerAddress!;
+}

--- a/tests/DependabotHelper.EndToEndTests/ResourceTests.cs
+++ b/tests/DependabotHelper.EndToEndTests/ResourceTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Net;
+using System.Net.Mime;
+
+namespace MartinCostello.DependabotHelper;
+
+public class ResourceTests : EndToEndTest
+{
+    public ResourceTests(AppFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper)
+    {
+    }
+
+    [SkippableTheory]
+    [InlineData("/", MediaTypeNames.Text.Html)]
+    [InlineData("/configure", MediaTypeNames.Text.Html)]
+    [InlineData("/sign-in", MediaTypeNames.Text.Html)]
+    [InlineData("/css/site.css", "text/css")]
+    [InlineData("/static/js/main.js", "application/javascript")]
+    [InlineData("/static/js/main.js.map", MediaTypeNames.Text.Plain)]
+    [InlineData("/favicon.png", "image/png")]
+    [InlineData("/humans.txt", MediaTypeNames.Text.Plain)]
+    [InlineData("/manifest.webmanifest", "application/manifest+json")]
+    [InlineData("/robots.txt", MediaTypeNames.Text.Plain)]
+    public async Task Can_Load_Resource_As_Get(string requestUri, string contentType)
+    {
+        // Arrange
+        using var client = Fixture.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync(requestUri);
+
+        // Assert
+        response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        response.Content.ShouldNotBeNull();
+        response.Content.Headers.ContentType.ShouldNotBeNull();
+        response.Content.Headers.ContentType.MediaType.ShouldNotBeNull();
+        response.Content.Headers.ContentType.MediaType.ShouldBe(contentType);
+    }
+}

--- a/tests/DependabotHelper.EndToEndTests/ResourceTests.cs
+++ b/tests/DependabotHelper.EndToEndTests/ResourceTests.cs
@@ -15,15 +15,18 @@ public class ResourceTests : EndToEndTest
 
     [SkippableTheory]
     [InlineData("/", MediaTypeNames.Text.Html)]
+    [InlineData("/bad-request.html", MediaTypeNames.Text.Html)]
     [InlineData("/configure", MediaTypeNames.Text.Html)]
-    [InlineData("/sign-in", MediaTypeNames.Text.Html)]
     [InlineData("/css/site.css", "text/css")]
-    [InlineData("/static/js/main.js", "application/javascript")]
-    [InlineData("/static/js/main.js.map", MediaTypeNames.Text.Plain)]
+    [InlineData("/error.html", MediaTypeNames.Text.Html)]
     [InlineData("/favicon.png", "image/png")]
     [InlineData("/humans.txt", MediaTypeNames.Text.Plain)]
     [InlineData("/manifest.webmanifest", "application/manifest+json")]
+    [InlineData("/not-found.html", MediaTypeNames.Text.Html)]
     [InlineData("/robots.txt", MediaTypeNames.Text.Plain)]
+    [InlineData("/sign-in", MediaTypeNames.Text.Html)]
+    [InlineData("/static/js/main.js", "application/javascript")]
+    [InlineData("/static/js/main.js.map", MediaTypeNames.Text.Plain)]
     public async Task Can_Load_Resource_As_Get(string requestUri, string contentType)
     {
         // Arrange
@@ -38,5 +41,57 @@ public class ResourceTests : EndToEndTest
         response.Content.Headers.ContentType.ShouldNotBeNull();
         response.Content.Headers.ContentType.MediaType.ShouldNotBeNull();
         response.Content.Headers.ContentType.MediaType.ShouldBe(contentType);
+    }
+
+    [SkippableFact]
+    public async Task Response_Headers_Contains_Expected_Headers()
+    {
+        // Arrange
+        string[] expectedHeaders =
+        {
+            "Content-Security-Policy",
+            "Expect-CT",
+            "Feature-Policy",
+            "Permissions-Policy",
+            "Referrer-Policy",
+            "X-Content-Type-Options",
+            "X-Download-Options",
+            "X-Frame-Options",
+            "X-Request-Id",
+            "X-XSS-Protection",
+        };
+
+        using var client = Fixture.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/");
+
+        // Assert
+        foreach (string expected in expectedHeaders)
+        {
+            response.Headers.Contains(expected).ShouldBeTrue($"The '{expected}' response header was not found.");
+        }
+    }
+
+    [SkippableFact]
+    public async Task Response_Headers_Does_Not_Contain_Unexpected_Headers()
+    {
+        // Arrange
+        string[] expectedHeaders =
+        {
+            "Server",
+            "X-Powered-By",
+        };
+
+        using var client = Fixture.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/");
+
+        // Assert
+        foreach (string expected in expectedHeaders)
+        {
+            response.Headers.Contains(expected).ShouldBeFalse($"The '{expected}' response header was found.");
+        }
     }
 }

--- a/tests/DependabotHelper.EndToEndTests/UITests.cs
+++ b/tests/DependabotHelper.EndToEndTests/UITests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.Playwright;
+
+namespace MartinCostello.DependabotHelper;
+
+public class UITests : EndToEndTest, IAsyncLifetime
+{
+    public UITests(AppFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper)
+    {
+    }
+
+    [SkippableFact]
+    public async Task Can_Load_Homepage()
+    {
+        // Arrange
+        using var playwright = await Playwright.CreateAsync();
+
+        var browserType = playwright[BrowserType.Chromium];
+
+        await using var browser = await browserType.LaunchAsync();
+        await using var context = await browser.NewContextAsync();
+
+        var page = await context.NewPageAsync();
+
+        // Act
+        await page.GotoAsync(Fixture.ServerAddress.ToString());
+        await page.WaitForLoadStateAsync();
+
+        // Assert
+        await Assertions.Expect(page.Locator("id=sign-in")).ToBeVisibleAsync();
+    }
+
+    public Task InitializeAsync()
+    {
+        int exitCode = Program.Main(new[] { "install" });
+
+        if (exitCode != 0)
+        {
+            throw new InvalidOperationException($"Playwright exited with code {exitCode}.");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/tests/DependabotHelper.EndToEndTests/xunit.runner.json
+++ b/tests/DependabotHelper.EndToEndTests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "methodDisplay": "method"
+}

--- a/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
+++ b/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
@@ -31,4 +31,12 @@
     <Using Include="Xunit" />
     <Using Include="Xunit.Abstractions" />
   </ItemGroup>
+  <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
+    <CollectCoverage>true</CollectCoverage>
+    <CoverletOutput Condition=" '$(OutputPath)' != '' ">$(OutputPath)/</CoverletOutput>
+    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
+    <Exclude>[*Tests]*,[xunit.*]*</Exclude>
+    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+    <Threshold>80</Threshold>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Add tests to run post-deployment.
- Enforce minimum code coverage of 80%.
- Add various headers to make securityheaders.io happy.
- Add static error pages for IIS failures.
- Fix text colour on 4xx error pages.

Resolves #16.
