### PR TITLE
Add basic webhook support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="ReportGenerator" Version="5.1.3" />
     <PackageVersion Include="Shouldly" Version="4.0.3" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.406" />
+    <PackageVersion Include="Terrajobst.GitHubEvents.AspNetCore" Version="0.1.14" />
     <PackageVersion Include="xunit" Version="2.4.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,4 +121,4 @@ the application.
 | `GitHub:ClientSecret` | `string` | - | The client secret for the GitHub OAuth application to use. |
 | `GitHub:EnterpriseDomain` | `string` | - | The URL of a GitHub Enterprise Server instance to use instead of GitHub.com. |
 | `GitHub:Scopes` | `string[]` | `[ "repo" ]` | The scope(s) to request for the OAuth token when a user authenticates with the application. |
-| `GitHub:WebhookSecret` | `string` | - | The option secret to use to validate GitHub webhook payloads. |
+| `GitHub:WebhookSecret` | `string` | - | The optional secret to use to validate GitHub webhook payloads. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,4 +121,5 @@ the application.
 | `GitHub:ClientSecret` | `string` | - | The client secret for the GitHub OAuth application to use. |
 | `GitHub:EnterpriseDomain` | `string` | - | The URL of a GitHub Enterprise Server instance to use instead of GitHub.com. |
 | `GitHub:Scopes` | `string[]` | `[ "repo" ]` | The scope(s) to request for the OAuth token when a user authenticates with the application. |
+| `GitHub:WebhookEndpoint` | `string` | '/github/webhook' | The path for the endpoint to accept GitHub webhook payloads. |
 | `GitHub:WebhookSecret` | `string` | - | The optional secret to use to validate GitHub webhook payloads. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,3 +121,4 @@ the application.
 | `GitHub:ClientSecret` | `string` | - | The client secret for the GitHub OAuth application to use. |
 | `GitHub:EnterpriseDomain` | `string` | - | The URL of a GitHub Enterprise Server instance to use instead of GitHub.com. |
 | `GitHub:Scopes` | `string[]` | `[ "repo" ]` | The scope(s) to request for the OAuth token when a user authenticates with the application. |
+| `GitHub:WebhookSecret` | `string` | - | The option secret to use to validate GitHub webhook payloads. |

--- a/src/DependabotHelper/DependabotHelper.csproj
+++ b/src/DependabotHelper/DependabotHelper.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
     <PackageReference Include="Octokit" />
     <PackageReference Include="Polly" />
+    <PackageReference Include="Terrajobst.GitHubEvents.AspNetCore" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="scripts\ts\**\*.ts" />

--- a/src/DependabotHelper/GitHubEndpoints.cs
+++ b/src/DependabotHelper/GitHubEndpoints.cs
@@ -23,7 +23,9 @@ public static class GitHubEndpoints
     /// </returns>
     public static IEndpointRouteBuilder MapGitHubRoutes(this IEndpointRouteBuilder builder, IConfiguration configuration, ILogger logger)
     {
-        builder.MapGitHubWebHook(secret: configuration["GitHub:WebhookSecret"]);
+        builder.MapGitHubWebHook(
+            configuration["GitHub:WebhookEndpoint"],
+            configuration["GitHub:WebhookSecret"]);
 
         builder.MapGet("/github/repos/{owner}", async (
             string owner,

--- a/src/DependabotHelper/GitHubEndpoints.cs
+++ b/src/DependabotHelper/GitHubEndpoints.cs
@@ -3,6 +3,7 @@
 
 using System.Security.Claims;
 using Microsoft.AspNetCore.Antiforgery;
+using Terrajobst.GitHubEvents.AspNetCore;
 
 namespace MartinCostello.DependabotHelper;
 
@@ -15,12 +16,15 @@ public static class GitHubEndpoints
     /// Maps the endpoints for GitHub.
     /// </summary>
     /// <param name="builder">The <see cref="IEndpointConventionBuilder"/>.</param>
+    /// <param name="configuration">The <see cref="IConfiguration"/> to use.</param>
     /// <param name="logger">The <see cref="ILogger"/> to use.</param>
     /// <returns>
     /// A <see cref="IEndpointConventionBuilder"/> that can be used to further customize the endpoint.
     /// </returns>
-    public static IEndpointRouteBuilder MapGitHubRoutes(this IEndpointRouteBuilder builder, ILogger logger)
+    public static IEndpointRouteBuilder MapGitHubRoutes(this IEndpointRouteBuilder builder, IConfiguration configuration, ILogger logger)
     {
+        builder.MapGitHubWebHook(secret: configuration["GitHub:WebhookSecret"]);
+
         builder.MapGet("/github/repos/{owner}", async (
             string owner,
             ClaimsPrincipal user,

--- a/src/DependabotHelper/GitHubEventProcessor.cs
+++ b/src/DependabotHelper/GitHubEventProcessor.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Terrajobst.GitHubEvents;
+
+namespace MartinCostello.DependabotHelper;
+
+public sealed class GitHubEventProcessor : IGitHubEventProcessor
+{
+    private readonly ILogger<GitHubEventProcessor> _logger;
+
+    public GitHubEventProcessor(ILogger<GitHubEventProcessor> logger)
+    {
+        _logger = logger;
+    }
+
+    public void Process(GitHubEvent message)
+    {
+        _logger.LogInformation("Received webhook with ID {HookId}.", message.HookId);
+    }
+}

--- a/src/DependabotHelper/GitHubExtensions.cs
+++ b/src/DependabotHelper/GitHubExtensions.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Octokit;
 using Octokit.Internal;
+using Terrajobst.GitHubEvents;
 
 namespace MartinCostello.DependabotHelper;
 
@@ -18,6 +20,8 @@ public static class GitHubExtensions
 
         services.AddSingleton<ICredentialStore, UserCredentialStore>();
         services.AddSingleton<IJsonSerializer, SimpleJsonSerializer>();
+
+        services.TryAddSingleton<IGitHubEventProcessor, GitHubEventProcessor>();
 
         services.AddScoped<GitHubService>();
         services.AddScoped<IHttpClient>((provider) =>

--- a/src/DependabotHelper/GitHubOptions.cs
+++ b/src/DependabotHelper/GitHubOptions.cs
@@ -12,4 +12,6 @@ public sealed class GitHubOptions
     public string EnterpriseDomain { get; set; } = string.Empty;
 
     public IList<string> Scopes { get; set; } = new List<string>();
+
+    public string WebhookSecret { get; set; } = string.Empty;
 }

--- a/src/DependabotHelper/GitHubOptions.cs
+++ b/src/DependabotHelper/GitHubOptions.cs
@@ -13,5 +13,7 @@ public sealed class GitHubOptions
 
     public IList<string> Scopes { get; set; } = new List<string>();
 
+    public string WebhookEndpoint { get; set; } = string.Empty;
+
     public string WebhookSecret { get; set; } = string.Empty;
 }

--- a/src/DependabotHelper/GitHubRateLimitMiddleware.cs
+++ b/src/DependabotHelper/GitHubRateLimitMiddleware.cs
@@ -5,7 +5,7 @@ using Octokit;
 
 namespace MartinCostello.DependabotHelper;
 
-public class GitHubRateLimitMiddleware
+public sealed class GitHubRateLimitMiddleware
 {
     private readonly RequestDelegate _next;
 

--- a/src/DependabotHelper/Program.cs
+++ b/src/DependabotHelper/Program.cs
@@ -40,6 +40,7 @@ if (!app.Environment.IsDevelopment())
 }
 
 app.UseMiddleware<CustomHttpHeadersMiddleware>();
+app.UseMiddleware<GitHubRateLimitMiddleware>();
 
 app.UseStatusCodePagesWithReExecute("/error", "?id={0}");
 
@@ -56,8 +57,7 @@ app.UseAuthorization();
 
 app.MapAuthenticationRoutes();
 
-app.MapGitHubRoutes(app.Logger);
-app.UseMiddleware<GitHubRateLimitMiddleware>();
+app.MapGitHubRoutes(app.Configuration, app.Logger);
 
 app.MapRazorPages();
 

--- a/src/DependabotHelper/appsettings.json
+++ b/src/DependabotHelper/appsettings.json
@@ -15,6 +15,7 @@
     "ClientSecret": "",
     "EnterpriseDomain": "",
     "Scopes": [ "repo" ],
+    "WebhookEndpoint": "/github/webhook",
     "WebhookSecret": ""
   },
   "Logging": {

--- a/src/DependabotHelper/appsettings.json
+++ b/src/DependabotHelper/appsettings.json
@@ -14,7 +14,8 @@
     "ClientId": "",
     "ClientSecret": "",
     "EnterpriseDomain": "",
-    "Scopes": [ "repo" ]
+    "Scopes": [ "repo" ],
+    "WebhookSecret": ""
   },
   "Logging": {
     "LogLevel": {

--- a/tests/DependabotHelper.Tests/ApiTests.cs
+++ b/tests/DependabotHelper.Tests/ApiTests.cs
@@ -1546,6 +1546,14 @@ public sealed class ApiTests : IntegrationTests<AppFixture>
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+        var processor = Fixture.Services.GetRequiredService<MockGitHubEventProcessor>();
+
+        processor.Events.Count.ShouldBe(1);
+        var actual = processor.Events.Dequeue();
+
+        actual.ShouldNotBeNull();
+        actual.BodyJson.ShouldBe(payload);
     }
 
     private static JsonSerializerOptions CreateSerializerOptions()

--- a/tests/DependabotHelper.Tests/ApiTests.cs
+++ b/tests/DependabotHelper.Tests/ApiTests.cs
@@ -1542,7 +1542,7 @@ public sealed class ApiTests : IntegrationTests<AppFixture>
         using var content = new StringContent(payload, Encoding.UTF8, "application/json");
 
         // Act
-        using var response = await client.PostAsync("/github-webhook", content);
+        using var response = await client.PostAsync("/github/webhook", content);
 
         // Assert
         response.StatusCode.ShouldBe(HttpStatusCode.OK);

--- a/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
+++ b/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <NoWarn>$(NoWarn);CA1054;CA1707;CA1711;CA1812;CA2007;CA2234;SA1600</NoWarn>
+    <NoWarn>$(NoWarn);CA1054;CA1308;CA1707;CA1711;CA1812;CA2007;CA2234;SA1600</NoWarn>
     <RootNamespace>MartinCostello.DependabotHelper</RootNamespace>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>

--- a/tests/DependabotHelper.Tests/GitHubEventProcessorTests.cs
+++ b/tests/DependabotHelper.Tests/GitHubEventProcessorTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Primitives;
+using Terrajobst.GitHubEvents;
+
+namespace MartinCostello.DependabotHelper;
+
+public class GitHubEventProcessorTests
+{
+    public GitHubEventProcessorTests(ITestOutputHelper outputHelper)
+    {
+        OutputHelper = outputHelper;
+    }
+
+    private ITestOutputHelper OutputHelper { get; }
+
+    [Fact]
+    public void Process_Does_Not_Throw()
+    {
+        // Arrange
+        var logger = OutputHelper.ToLogger<GitHubEventProcessor>();
+        var target = new GitHubEventProcessor(logger);
+
+        var message = new GitHubEvent(
+            "User-Agent",
+            "delivery",
+            "event",
+            "hook-id",
+            "hook-installation-target-id",
+            "hook-installation-target-type",
+            new Dictionary<string, StringValues>(),
+            new(),
+            "{}");
+
+        // Assert
+        target.Process(message);
+    }
+}

--- a/tests/DependabotHelper.Tests/Infrastructure/AppFixture.cs
+++ b/tests/DependabotHelper.Tests/Infrastructure/AppFixture.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Terrajobst.GitHubEvents;
 
 namespace MartinCostello.DependabotHelper.Infrastructure;
 
@@ -110,6 +111,9 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
 
             services.AddSingleton<IPostConfigureOptions<GitHubAuthenticationOptions>, RemoteAuthorizationEventsFilter>();
             services.AddScoped<LoopbackOAuthEvents>();
+
+            services.AddSingleton<MockGitHubEventProcessor>();
+            services.AddSingleton<IGitHubEventProcessor>((p) => p.GetRequiredService<MockGitHubEventProcessor>());
         });
 
         Interceptor.RegisterBundle(Path.Combine("Bundles", "oauth-http-bundle.json"));

--- a/tests/DependabotHelper.Tests/Infrastructure/AppFixture.cs
+++ b/tests/DependabotHelper.Tests/Infrastructure/AppFixture.cs
@@ -84,6 +84,7 @@ public class AppFixture : WebApplicationFactory<Program>, ITestOutputHelperAcces
                 KeyValuePair.Create("GitHub:ClientId", "github-id"),
                 KeyValuePair.Create("GitHub:ClientSecret", "github-secret"),
                 KeyValuePair.Create("GitHub:EnterpriseDomain", string.Empty),
+                KeyValuePair.Create("GitHub:WebhookSecret", "github-secret"),
                 KeyValuePair.Create("Site:Domain", "dependabot.local"),
             };
 

--- a/tests/DependabotHelper.Tests/Infrastructure/MockGitHubEventProcessor.cs
+++ b/tests/DependabotHelper.Tests/Infrastructure/MockGitHubEventProcessor.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using Terrajobst.GitHubEvents;
+
+namespace MartinCostello.DependabotHelper.Infrastructure;
+
+public class MockGitHubEventProcessor : IGitHubEventProcessor
+{
+    public Queue<GitHubEvent> Events { get; } = new Queue<GitHubEvent>();
+
+    public void Process(GitHubEvent message)
+    {
+        Events.Enqueue(message);
+    }
+}


### PR DESCRIPTION
Add (very) basic webhook endpoint using `Terrajobst.GitHubEvents.AspNetCore`.

At this point, it's effectively just a proof-of-concept for future expansion, with the hook just printing a log message and not doing anything else.

It's registered with `TryAddSingleton()` so that any hosting modules (or tests) can add their own implementation to use instead with whatever custom logic.
