### PR TITLE
Remove duplicate package reference

### DIFF
--- a/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
+++ b/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="JustEat.HttpClientInterception" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />


### PR DESCRIPTION
`GitHubActionsTestLogger` is already imported by `Directory.Build.props`.
