### PR TITLE
Reduce GitHub API usage

### DIFF
--- a/src/DependabotHelper/GitHubService.cs
+++ b/src/DependabotHelper/GitHubService.cs
@@ -735,7 +735,7 @@ public sealed class GitHubService
     {
         absoluteExpirationRelativeToNow ??= _options.CacheLifetime;
 
-        if (_options.DisableCaching || absoluteExpirationRelativeToNow < TimeSpan.FromMinutes(1))
+        if (_options.DisableCaching || absoluteExpirationRelativeToNow < ShortCacheLifetime)
         {
             return await factory();
         }


### PR DESCRIPTION
- Add more caching for GitHub API responses to reduce API usage.
- Support call sites to cached data using custom expiry periods separate to the configured limit.

Resolves #106.
