### PR TITLE
Do not cache approvals

### DIFF
--- a/src/DependabotHelper/GitHubService.cs
+++ b/src/DependabotHelper/GitHubService.cs
@@ -386,10 +386,7 @@ public sealed class GitHubService
             owner,
             name);
 
-        var approved = await CacheGetOrCreateAsync(user, $"reviews:{owner}:{name}:{number}", ShortCacheLifetime, async () =>
-        {
-            return await _client.PullRequest.Review.GetAll(owner, name, number);
-        });
+        var approved = await _client.PullRequest.Review.GetAll(owner, name, number);
 
         _logger.LogDebug(
             "Found {Count} approvals for pull request {Number} in repository {Owner}/{Name}.",


### PR DESCRIPTION
Do not cache the number of approvals as it also breaks the UI when PRs are merged, like with #140.
