### PR TITLE
Paging fixes

### DIFF
--- a/src/DependabotHelper/DependabotOptions.cs
+++ b/src/DependabotHelper/DependabotOptions.cs
@@ -17,6 +17,10 @@ public sealed class DependabotOptions
 
     public IList<TimeSpan> MergeRetryWaits { get; set; } = new List<TimeSpan>();
 
+    public int PageCount { get; set; } = 1;
+
+    public int PageSize { get; set; } = 25;
+
     public TimeSpan? RefreshPeriod { get; set; }
 
     public IList<string> Users { get; set; } = new List<string>();

--- a/src/DependabotHelper/GitHubService.cs
+++ b/src/DependabotHelper/GitHubService.cs
@@ -370,7 +370,9 @@ public sealed class GitHubService
             }
         }
 
-        return result;
+        return result
+            .OrderByDescending((p) => p.Number)
+            .ToList();
     }
 
     private async Task<(bool CanApprove, bool IsApproved)> IsApprovedAsync(

--- a/src/DependabotHelper/GitHubService.cs
+++ b/src/DependabotHelper/GitHubService.cs
@@ -693,6 +693,12 @@ public sealed class GitHubService
             request.Labels.Add(label);
         }
 
+        var options = new ApiOptions()
+        {
+            PageCount = _options.PageCount,
+            PageSize = _options.PageSize,
+        };
+
         _logger.LogInformation(
             "Finding open issues created by {User} in repository {Owner}/{Name}.",
             creator,
@@ -703,7 +709,7 @@ public sealed class GitHubService
 
         var issues = await CacheGetOrCreateAsync(user, $"issues:{owner}:{name}:{creator}", cacheLifetime, async () =>
         {
-            return await _client.Issue.GetAllForRepository(owner, name, request);
+            return await _client.Issue.GetAllForRepository(owner, name, request, options);
         });
 
         var openPullRequests = issues

--- a/src/DependabotHelper/appsettings.json
+++ b/src/DependabotHelper/appsettings.json
@@ -10,6 +10,8 @@
     "IncludePrivate": false,
     "Labels": [ "dependencies" ],
     "MergeRetryWaits": [ "00:00:01", "00:00:02" ],
+    "PageCount": 1,
+    "PageSize": 25,
     "RefreshPeriod": "00:10:00",
     "Users": [ "app/dependabot", "app/github-actions" ]
   },

--- a/tests/DependabotHelper.Tests/Infrastructure/IntegrationTests`1.cs
+++ b/tests/DependabotHelper.Tests/Infrastructure/IntegrationTests`1.cs
@@ -144,7 +144,7 @@ public abstract class IntegrationTests<T> : IAsyncLifetime
         CreateDefaultBuilder()
             .Requests()
             .ForPath($"/repos/{repository.Owner.Login}/{repository.Name}/issues")
-            .ForQuery($"creator={encodedCreator}&filter=created&state=open&labels=dependencies&sort=created&direction=desc")
+            .ForQuery($"creator={encodedCreator}&filter=created&state=open&labels=dependencies&sort=created&direction=desc&per_page=25")
             .Responds()
             .WithJsonContent(response)
             .RegisterWith(Fixture.Interceptor);


### PR DESCRIPTION
- Limit the number of issues returned in GitHub API queries to 25, contributes to #106.
- Sort PRs by number so that issues from more than one user are correctly interleaved, rather than grouped by user.
