### PR TITLE
Handle SecondaryRateLimitExceededException

### DIFF
--- a/src/DependabotHelper/Pages/Home/Configure.cshtml.cs
+++ b/src/DependabotHelper/Pages/Home/Configure.cshtml.cs
@@ -29,5 +29,9 @@ public sealed class ConfigureModel : PageModel
         {
             // Ignore and let the page load
         }
+        catch (Octokit.SecondaryRateLimitExceededException)
+        {
+            // Ignore and let the page load
+        }
     }
 }

--- a/src/DependabotHelper/Pages/Home/Index.cshtml.cs
+++ b/src/DependabotHelper/Pages/Home/Index.cshtml.cs
@@ -33,5 +33,9 @@ public sealed class IndexModel : PageModel
         {
             // Ignore and let the page load
         }
+        catch (Octokit.SecondaryRateLimitExceededException)
+        {
+            // Ignore and let the page load
+        }
     }
 }

--- a/src/DependabotHelper/ResultsExtensions.cs
+++ b/src/DependabotHelper/ResultsExtensions.cs
@@ -32,7 +32,7 @@ internal static class ResultsExtensions
             logger.LogInformation(exception, "Unauthorized.");
             return Results.Problem(statusCode: StatusCodes.Status401Unauthorized);
         }
-        else if (exception is RateLimitExceededException)
+        else if (exception is RateLimitExceededException || exception is SecondaryRateLimitExceededException)
         {
             logger.LogWarning(exception, "API rate limit exceeded.");
             return Results.Problem(


### PR DESCRIPTION
Handle the new `SecondaryRateLimitExceededException` exception type from Octokit 1.0.0 as an HTTP 429 where appropriate.
