### PR TITLE
Do not override CoverletOutputFormat

### DIFF
--- a/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
+++ b/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
@@ -33,7 +33,7 @@
   <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutput Condition=" '$(OutputPath)' != '' ">$(OutputPath)/</CoverletOutput>
-    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
+    <CoverletOutputFormat Condition=" '$(CoverletOutputFormat)' == '' ">cobertura,json</CoverletOutputFormat>
     <Exclude>[*Tests]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
     <Threshold>80</Threshold>


### PR DESCRIPTION
Only set the value of `CoverletOutputFormat` if it doesn't already have a value.
