### PR TITLE
Remove Feature-Policy

### DIFF
--- a/src/DependabotHelper/CustomHttpHeadersMiddleware.cs
+++ b/src/DependabotHelper/CustomHttpHeadersMiddleware.cs
@@ -68,7 +68,6 @@ public sealed class CustomHttpHeadersMiddleware
                 context.Response.Headers["Expect-CT"] = "max-age=1800";
             }
 
-            context.Response.Headers["Feature-Policy"] = "accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none'; magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'";
             context.Response.Headers["Permissions-Policy"] = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()";
             context.Response.Headers["Referrer-Policy"] = "no-referrer-when-downgrade";
             context.Response.Headers["X-Content-Type-Options"] = "nosniff";

--- a/tests/DependabotHelper.EndToEndTests/ResourceTests.cs
+++ b/tests/DependabotHelper.EndToEndTests/ResourceTests.cs
@@ -51,7 +51,6 @@ public class ResourceTests : EndToEndTest
         {
             "Content-Security-Policy",
             "Expect-CT",
-            "Feature-Policy",
             "Permissions-Policy",
             "Referrer-Policy",
             "X-Content-Type-Options",

--- a/tests/DependabotHelper.Tests/ResourceTests.cs
+++ b/tests/DependabotHelper.Tests/ResourceTests.cs
@@ -170,7 +170,6 @@ public sealed class ResourceTests : IntegrationTests<AppFixture>
         {
             "Content-Security-Policy",
             "Expect-CT",
-            "Feature-Policy",
             "Permissions-Policy",
             "Referrer-Policy",
             "X-Content-Type-Options",


### PR DESCRIPTION
Remove `Feature-Policy` to fix warning in Chrome when used with `Permissions-Policy`.

<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
