### PR TITLE
Enable auto-merge if merge fails

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="4.7.4" />
     <PackageVersion Include="Moq" Version="4.18.2" />
     <PackageVersion Include="Octokit" Version="2.0.0" />
+    <PackageVersion Include="Octokit.GraphQL" Version="0.1.8-beta" />
     <PackageVersion Include="Polly" Version="7.2.3" />
     <PackageVersion Include="ReportGenerator" Version="5.1.9" />
     <PackageVersion Include="Shouldly" Version="4.0.3" />

--- a/src/DependabotHelper/DependabotHelper.csproj
+++ b/src/DependabotHelper/DependabotHelper.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Humanizer" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
     <PackageReference Include="Octokit" />
+    <PackageReference Include="Octokit.GraphQL" />
     <PackageReference Include="Polly" />
   </ItemGroup>
   <ItemGroup>

--- a/src/DependabotHelper/Models/PullRequest.cs
+++ b/src/DependabotHelper/Models/PullRequest.cs
@@ -11,6 +11,8 @@ public sealed class PullRequest
 
     public bool IsApproved { get; set; }
 
+    public string NodeId { get; set; } = default!;
+
     public int Number { get; set; }
 
     public string RepositoryOwner { get; set; } = default!;

--- a/src/DependabotHelper/UserCredentialStore.cs
+++ b/src/DependabotHelper/UserCredentialStore.cs
@@ -5,7 +5,7 @@ using Octokit;
 
 namespace MartinCostello.DependabotHelper;
 
-public sealed class UserCredentialStore : ICredentialStore
+public sealed class UserCredentialStore : ICredentialStore, Octokit.GraphQL.ICredentialStore
 {
     private readonly IHttpContextAccessor _accessor;
 
@@ -18,5 +18,11 @@ public sealed class UserCredentialStore : ICredentialStore
     {
         string token = await _accessor.HttpContext!.GetAccessTokenAsync();
         return new Credentials(token);
+    }
+
+    async Task<string> Octokit.GraphQL.ICredentialStore.GetCredentials(CancellationToken cancellationToken)
+    {
+        var credentials = await GetCredentials();
+        return credentials.GetToken();
     }
 }

--- a/tests/DependabotHelper.Tests/ApiTests.cs
+++ b/tests/DependabotHelper.Tests/ApiTests.cs
@@ -256,6 +256,7 @@ public sealed class ApiTests : IntegrationTests<AppFixture>
         RegisterGetRepository(repository);
         RegisterPutPullRequestMerge(pullRequest1, mergeable: true);
         RegisterPutPullRequestMerge(pullRequest5, mergeable: false);
+        RegisterEnableAutomerge(pullRequest5);
 
         RegisterGetIssues(
             repository,

--- a/tests/DependabotHelper.Tests/Builders/PullRequestBuilder.cs
+++ b/tests/DependabotHelper.Tests/Builders/PullRequestBuilder.cs
@@ -22,6 +22,8 @@ public sealed class PullRequestBuilder : ResponseBuilder
 
     public bool? IsMergeable { get; set; }
 
+    public string NodeId { get; set; } = RandomString();
+
     public int Number { get; set; } = RandomNumber();
 
     public RepositoryBuilder Repository { get; set; }
@@ -43,6 +45,7 @@ public sealed class PullRequestBuilder : ResponseBuilder
             number = Number,
             draft = IsDraft,
             mergeable = IsMergeable,
+            node_id = NodeId,
             title = Title,
             @base = new
             {


### PR DESCRIPTION
If merging a pull request fails because it is not mergeable, then enable auto-merge for it instead. This is useful in the scenario where two pull requests conflict with each other and dependabot then rebases so that it will merge itself eventually.

Also only requests the merge policy for a repository if there's at least one pull request that is a merge candidate.
