### PR TITLE
Add .npmrc

### DIFF
--- a/src/DependabotHelper/.npmrc
+++ b/src/DependabotHelper/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org


### PR DESCRIPTION
Add an `.npmrc` file to ensure the right package registry is always used.
