### PR TITLE
Bump Octokit.GraphQL to 0.2.0-beta

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="4.9.4" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Octokit" Version="4.0.3" />
-    <PackageVersion Include="Octokit.GraphQL" Version="0.1.8-beta" />
+    <PackageVersion Include="Octokit.GraphQL" Version="0.2.0-beta" />
     <PackageVersion Include="Polly" Version="7.2.3" />
     <PackageVersion Include="ReportGenerator" Version="5.1.13" />
     <PackageVersion Include="Shouldly" Version="4.1.0" />


### PR DESCRIPTION
Update to the latest release of Octokit.GraphQL.
