### PR TITLE
Hide merge method dropdown

### DIFF
--- a/src/DependabotHelper/scripts/ts/View/RepositoryElement.ts
+++ b/src/DependabotHelper/scripts/ts/View/RepositoryElement.ts
@@ -54,6 +54,16 @@ export class RepositoryElement {
                 try {
                     Elements.disable(this.mergeButton);
                     Elements.disable(this.mergeMethodsButton);
+
+                    if ('bootstrap' in window) {
+                        const bootstrap: any = window['bootstrap' as any];
+                        const dropdown = bootstrap['Dropdown' as any];
+                        const methodDropdown = dropdown.getInstance(this.mergeMethodsButton);
+                        if (methodDropdown) {
+                            methodDropdown.hide();
+                        }
+                    }
+
                     this.showLoader(this.mergeButton);
 
                     const mergeMethodString = this.mergeButton.getAttribute(mergeMethodAttributeName);


### PR DESCRIPTION
Fix merge method dropdown being left visible when opened but nothing is clicked before clicking the merge button.

<details>

<summary>🖼️ Screenshot</summary>

![Image](https://user-images.githubusercontent.com/1439341/224357829-2ccf233e-af3c-408a-a81b-67b014313a59.jpeg)

</details>
