### PR TITLE
Show pending approvals and repository name in pull request modal

### DIFF
--- a/src/DependabotHelper/Pages/Home/Index.cshtml
+++ b/src/DependabotHelper/Pages/Home/Index.cshtml
@@ -107,13 +107,13 @@
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="pr-label">Dependabot pull requests</h5>
+                <h5 class="modal-title" id="pr-label">Dependabot pull requests for <span class="pr-repo"></span></h5>
                 <button type="button" class="btn-close close" data-bs-dismiss="modal" aria-label="Close" analytics-event="close_pull_requests_modal"></button>
             </div>
             <div class="modal-body">
                 <div class="table-responsive">
                     <table class="table">
-                        <caption>Open Dependabot pull requests.</caption>
+                        <caption>Open Dependabot pull requests for <span class="pr-repo"></span>.</caption>
                         <thead>
                             <tr>
                                 <th scope="col">Title</th>

--- a/src/DependabotHelper/Pages/Home/Index.cshtml
+++ b/src/DependabotHelper/Pages/Home/Index.cshtml
@@ -139,7 +139,8 @@
                                         <span class="fa-solid fa-check text-success pr-status-success d-none" data-count="0" aria-label="Success" title="Success"></span>
                                     </span>
                                     <span>
-                                        <span class="fa-solid fa-thumbs-up text-primary pr-is-approved d-none" data-count="0" aria-label="Approved" title="Approved"></span>
+                                        <span class="fa-solid fa-thumbs-up text-primary pr-is-approved d-none" aria-label="Approved" title="Approved"></span>
+                                        <span class="fa-solid fa-thumbs-up text-secondary pr-approval-pending d-none" aria-label="Pending further approvals from others" title="Pending further approvals from others"></span>
                                         <button class="btn btn-success btn-approve pr-approve d-none" type="button" aria-label="Approve this pull request" analytics-event="approve_pull_request">
                                             <span>Approve</span>
                                             <span class="fa-solid fa-check d-none d-md-inline-block" aria-hidden="true"></span>

--- a/src/DependabotHelper/scripts/ts/View/PullRequestsElement.ts
+++ b/src/DependabotHelper/scripts/ts/View/PullRequestsElement.ts
@@ -82,6 +82,8 @@ export class PullRequestsElement {
             });
 
             Elements.show(approveButton);
+        } else {
+            Elements.show(element.querySelector('.pr-approval-pending'));
         }
 
         Elements.show(element);

--- a/src/DependabotHelper/scripts/ts/View/PullRequestsElement.ts
+++ b/src/DependabotHelper/scripts/ts/View/PullRequestsElement.ts
@@ -32,6 +32,11 @@ export class PullRequestsElement {
         for (const pullRequest of pullRequests) {
             this.createRow(body, pullRequest);
         }
+
+        const names = document.querySelectorAll<HTMLElement>('.pr-repo');
+        for (const name of names) {
+            name.innerText = `${pullRequests[0].repositoryOwner}/${pullRequests[0].repositoryName}`;
+        }
     }
 
     private createRow(body: Element, pullRequest: PullRequest) {


### PR DESCRIPTION
- Add an element to clarify when a pull request has been approved by the logged-in user, but needs further approvals to be fully approved.
 Resolves #503.
- Add the full repository name to the pull request modal. Resolves #495.

![image](https://user-images.githubusercontent.com/1439341/225568220-01de5502-30d7-446b-a57d-88a2b70073e8.png)

![image](https://user-images.githubusercontent.com/1439341/225568393-84ef1fd7-1c20-4c70-8566-29756ea90ac2.png)

