### PR TITLE
Remove redundant suppression

### DIFF
--- a/src/DependabotHelper/Program.cs
+++ b/src/DependabotHelper/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using System.IO.Compression;
 using MartinCostello.DependabotHelper;
 using Microsoft.AspNetCore.HttpOverrides;


### PR DESCRIPTION
Remove now-redundant suppression for false-positive code analysis warning.
