### PR TITLE
Do not overwrite property

### DIFF
--- a/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
+++ b/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
@@ -33,7 +33,7 @@
   <PropertyGroup Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
     <CollectCoverage>true</CollectCoverage>
     <CoverletOutput Condition=" '$(OutputPath)' != '' ">$(OutputPath)/</CoverletOutput>
-    <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
+    <CoverletOutputFormat>cobertura,json,$(CoverletOutputFormat)</CoverletOutputFormat>
     <Exclude>[*Tests]*,[xunit.*]*</Exclude>
     <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
     <Threshold>80</Threshold>


### PR DESCRIPTION
Do not overwrite the `$(CoverletOutputFormat)` MSBuild property if it has any existing additional values.
