### PR TITLE
Treat skipped suites as successful

### DIFF
--- a/src/DependabotHelper/GitHubService.cs
+++ b/src/DependabotHelper/GitHubService.cs
@@ -645,8 +645,9 @@ public sealed class GitHubService
             // might not be required to run at all (e.g. an old installation)
             // as it would otherwise block the Pull Request from being successful.
             static bool IsSuccess(CheckSuite suite)
-                => suite.Conclusion == CheckConclusion.Success ||
-                   suite.Conclusion == CheckConclusion.Neutral;
+                => suite.Conclusion == CheckConclusion.Neutral ||
+                   suite.Conclusion == CheckConclusion.Skipped ||
+                   suite.Conclusion == CheckConclusion.Success;
 
             if (applicableSuites.All(IsSuccess))
             {

--- a/tests/DependabotHelper.Tests/ApiTests.cs
+++ b/tests/DependabotHelper.Tests/ApiTests.cs
@@ -1437,6 +1437,7 @@ public sealed class ApiTests : IntegrationTests<AppFixture>
 
     [Theory]
     [InlineData("completed", "neutral")]
+    [InlineData("completed", "skipped")]
     [InlineData("completed", "success")]
     public async Task Can_Get_Pull_Requests_When_Check_Suite_Success_When_No_Required_Statuses(string status, string? conclusion)
     {


### PR DESCRIPTION
Treat skipped checked suites as successful to prevent pull requests appearing to be permanently pending.
