### PR TITLE
Exclude [GeneratedCode]

### DIFF
--- a/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
+++ b/tests/DependabotHelper.Tests/DependabotHelper.Tests.csproj
@@ -35,7 +35,7 @@
     <CoverletOutput>$([System.IO.Path]::Combine($(OutputPath), 'coverage', 'coverage'))</CoverletOutput>
     <CoverletOutputFormat>$(CoverletOutputFormat),cobertura</CoverletOutputFormat>
     <Exclude>[*Tests]*,[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
-    <Threshold>80</Threshold>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+    <Threshold>85</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Exclude code decorated with `[GeneratedCode]` from code coverage.
