### PR TITLE
Bump Octokit.GraphQL to 0.2.1-beta

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.1.5" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Octokit" Version="7.0.1" />
-    <PackageVersion Include="Octokit.GraphQL" Version="0.2.0-beta" />
+    <PackageVersion Include="Octokit.GraphQL" Version="0.2.1-beta" />
     <PackageVersion Include="Polly" Version="7.2.4" />
     <PackageVersion Include="ReportGenerator" Version="5.1.23" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />


### PR DESCRIPTION
Bumps the Octokit.GraphQL package to 0.2.1-beta.
