### PR TITLE
Bump Amazon.Lambda.RuntimeSupport

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Amazon.Lambda.AspNetCoreServer.Hosting" Version="1.6.0" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.9.0" />
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="7.0.4" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.2.2" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.2" />

--- a/src/DependabotHelper/DependabotHelper.csproj
+++ b/src/DependabotHelper/DependabotHelper.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer.Hosting" />
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" />
     <PackageReference Include="AspNet.Security.OAuth.GitHub" />
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" />


### PR DESCRIPTION
Add an explicit reference to the Amazon.Lambda.RuntimeSupport NuGet package to use the most up-to-date version.
