### PR TITLE
Restore Polly.Core reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.3.3" />
     <PackageVersion Include="Octokit" Version="9.1.0" />
     <PackageVersion Include="Octokit.GraphQL" Version="0.2.1-beta" />
+    <PackageVersion Include="Polly.Core" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.Extensions" Version="$(PollyVersion)" />
     <PackageVersion Include="Polly.RateLimiting" Version="$(PollyVersion)" />
     <PackageVersion Include="ReportGenerator" Version="5.2.0" />

--- a/src/DependabotHelper/DependabotHelper.csproj
+++ b/src/DependabotHelper/DependabotHelper.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
     <PackageReference Include="Octokit" />
     <PackageReference Include="Octokit.GraphQL" />
+    <PackageReference Include="Polly.Core" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="Polly.RateLimiting" />
   </ItemGroup>


### PR DESCRIPTION
Reverts martincostello/dependabot-helper#1046, as otherwise the bug fixes in versions above the transient references won't pull through.
