### PR TITLE
Configure HSTS

### DIFF
--- a/src/DependabotHelper/Program.cs
+++ b/src/DependabotHelper/Program.cs
@@ -12,6 +12,7 @@ builder.Host.ConfigureApplication();
 
 builder.Services.AddGitHubAuthentication(builder.Configuration, builder.Environment);
 builder.Services.AddGitHubClient();
+builder.Services.AddHsts((options) => options.MaxAge = TimeSpan.FromDays(180));
 builder.Services.AddRazorPages();
 builder.Services.AddResponseCaching();
 


### PR DESCRIPTION
Configure an HSTS max-age of 180 days to get an A+ from Qualys SSL Labs Test.
