### PR TITLE
Fix CodeQL warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,7 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.3" />
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
-    <PackageVersion Include="Azure.Identity" Version="1.11.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.11.1" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />

--- a/src/DependabotHelper/GitHubService.cs
+++ b/src/DependabotHelper/GitHubService.cs
@@ -116,12 +116,9 @@ public sealed class GitHubService(
             Name = repository.Name,
         };
 
-        foreach (var method in GetMergeMethods())
+        foreach (var method in GetMergeMethods().Where((p) => IsValidMergeMethod(p, repository)))
         {
-            if (IsValidMergeMethod(method, repository))
-            {
-                result.MergeMethods.Add(method.ToString());
-            }
+            result.MergeMethods.Add(method.ToString());
         }
 
         if (await IsDependabotEnabledAsync(user, owner, name))
@@ -155,18 +152,10 @@ public sealed class GitHubService(
             else
             {
                 var current = await client.User.Current();
-
-                if (current.Id == ownerUser.Id)
-                {
-                    repos = await client.Repository.GetAllForCurrent(new RepositoryRequest()
-                    {
-                        Type = RepositoryType.Owner,
-                    });
-                }
-                else
-                {
-                    repos = await client.Repository.GetAllForUser(owner);
-                }
+                repos =
+                    current.Id == ownerUser.Id ?
+                    await client.Repository.GetAllForCurrent(new RepositoryRequest() { Type = RepositoryType.Owner }) :
+                    await client.Repository.GetAllForUser(owner);
             }
 
             return repos;

--- a/src/DependabotHelper/IHostBuilderExtensions.cs
+++ b/src/DependabotHelper/IHostBuilderExtensions.cs
@@ -70,17 +70,16 @@ public static class IHostBuilderExtensions
         string? clientSecret = configuration["AzureKeyVault:ClientSecret"];
         string? tenantId = configuration["AzureKeyVault:TenantId"];
 
-        if (!string.IsNullOrEmpty(clientId) &&
+        bool useClientSecret =
+            !string.IsNullOrEmpty(clientId) &&
             !string.IsNullOrEmpty(clientSecret) &&
-            !string.IsNullOrEmpty(tenantId))
-        {
-            // Use explicitly configured Azure Key Vault credentials
-            return new ClientSecretCredential(tenantId, clientId, clientSecret);
-        }
-        else
-        {
-            // Assume Managed Service Identity is configured and available
-            return new ManagedIdentityCredential();
-        }
+            !string.IsNullOrEmpty(tenantId);
+
+        // Use explicitly configured Azure Key Vault credentials, otherwise
+        // Assume Managed Service Identity is configured and available.
+        return
+            useClientSecret ?
+            new ClientSecretCredential(tenantId, clientId, clientSecret) :
+            new ManagedIdentityCredential();
     }
 }

--- a/tests/DependabotHelper.Tests/ApiTests.cs
+++ b/tests/DependabotHelper.Tests/ApiTests.cs
@@ -252,7 +252,7 @@ public sealed class ApiTests(AppFixture fixture, ITestOutputHelper outputHelper)
 
         var pullRequest1 = repository.CreatePullRequest();
         var pullRequest2 = repository.CreatePullRequest();
-        var pullRequest3 = repository.CreatePullRequest();
+        repository.CreatePullRequest();
         var pullRequest4 = repository.CreatePullRequest();
         var pullRequest5 = repository.CreatePullRequest();
 

--- a/tests/DependabotHelper.Tests/UITests.cs
+++ b/tests/DependabotHelper.Tests/UITests.cs
@@ -182,7 +182,7 @@ public class UITests(HttpServerFixture fixture, ITestOutputHelper outputHelper) 
             // Act - Select some of the repositories and save the changes
             await repositories[1].ToggleAsync();
             await repositories[3].ToggleAsync();
-            configurePage = await modal.SaveChangesAsync();
+            await modal.SaveChangesAsync();
 
             // Assert - Check the selected repositories are enabled
             modal = await owners[0].ConfigureAsync();
@@ -200,7 +200,7 @@ public class UITests(HttpServerFixture fixture, ITestOutputHelper outputHelper) 
             await repositories[1].ToggleAsync();
             await repositories[3].ToggleAsync();
 
-            configurePage = await modal.CloseAsync();
+            await modal.CloseAsync();
 
             // Assert - The selected repositories remains the same
             modal = await owners[0].ConfigureAsync();


### PR DESCRIPTION
- Bump Azure.Identity to 1.11.1 to resolve security vulnerability.
- Fix warnings from extended CodeQL analysis in #1244.
