### PR TITLE
Add resource detectors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.8.0" />
     <PackageVersion Include="OpenTelemetry.ResourceDetectors.Azure" Version="1.0.0-beta.6" />
+    <PackageVersion Include="OpenTelemetry.ResourceDetectors.Container" Version="1.0.0-beta.7" />
     <PackageVersion Include="Polly.Core" Version="8.4.0" />
     <PackageVersion Include="Polly.Extensions" Version="8.4.0" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.4.0" />

--- a/src/DependabotHelper/DependabotHelper.csproj
+++ b/src/DependabotHelper/DependabotHelper.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
     <PackageReference Include="OpenTelemetry.ResourceDetectors.Azure" />
+    <PackageReference Include="OpenTelemetry.ResourceDetectors.Container" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="Polly.RateLimiting" />
   </ItemGroup>

--- a/src/DependabotHelper/TelemetryExtensions.cs
+++ b/src/DependabotHelper/TelemetryExtensions.cs
@@ -8,9 +8,9 @@ using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
-using OpenTelemetry.Trace;
 using OpenTelemetry.ResourceDetectors.Azure;
 using OpenTelemetry.ResourceDetectors.Container;
+using OpenTelemetry.Trace;
 
 namespace MartinCostello.DependabotHelper;
 

--- a/src/DependabotHelper/TelemetryExtensions.cs
+++ b/src/DependabotHelper/TelemetryExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
 using System.Collections.Concurrent;
@@ -9,6 +9,8 @@ using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using OpenTelemetry.ResourceDetectors.Azure;
+using OpenTelemetry.ResourceDetectors.Container;
 
 namespace MartinCostello.DependabotHelper;
 
@@ -26,7 +28,10 @@ public static class TelemetryExtensions
         ArgumentNullException.ThrowIfNull(services);
 
         var resourceBuilder = ResourceBuilder.CreateDefault()
-            .AddService(ApplicationTelemetry.ServiceName, serviceVersion: ApplicationTelemetry.ServiceVersion);
+            .AddService(ApplicationTelemetry.ServiceName, serviceVersion: ApplicationTelemetry.ServiceVersion)
+            .AddDetector(new AppServiceResourceDetector())
+            .AddDetector(new ContainerResourceDetector());
+
         if (IsAzureMonitorConfigured())
         {
             services.Configure<AzureMonitorExporterOptions>(

--- a/src/DependabotHelper/TelemetryExtensions.cs
+++ b/src/DependabotHelper/TelemetryExtensions.cs
@@ -7,9 +7,9 @@ using Azure.Monitor.OpenTelemetry.Exporter;
 using Microsoft.Extensions.Options;
 using OpenTelemetry.Instrumentation.Http;
 using OpenTelemetry.Metrics;
-using OpenTelemetry.Resources;
 using OpenTelemetry.ResourceDetectors.Azure;
 using OpenTelemetry.ResourceDetectors.Container;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 
 namespace MartinCostello.DependabotHelper;


### PR DESCRIPTION
Add missing Azure resource detector and adds a container resource detector.

Resolves #1325.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/martincostello/dependabot-helper/issues/1325?shareId=80631b9f-525d-4328-8570-dd3420957c8b).