### PR TITLE
Fix some native AoT warnings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,8 @@
     <PackageVersion Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.3" />
     <PackageVersion Include="Azure.Identity" Version="1.11.3" />
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.2.0" />
+    <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.20.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.2" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
@@ -23,6 +25,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.44.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.4.4" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Octokit" Version="11.0.1" />
     <PackageVersion Include="Octokit.GraphQL" Version="0.4.0-beta" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />

--- a/src/DependabotHelper/ApplicationLambdaSerializer.cs
+++ b/src/DependabotHelper/ApplicationLambdaSerializer.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
+// Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using Amazon.Lambda.Serialization.SystemTextJson;
+
+namespace MartinCostello.DependabotHelper;
+
+internal sealed class ApplicationLambdaSerializer() : SourceGeneratorLambdaJsonSerializer<ApplicationJsonSerializerContext>()
+{
+    protected override JsonSerializerOptions CreateDefaultJsonSerializationOptions()
+        => new(ApplicationJsonSerializerContext.Default.Options);
+}

--- a/src/DependabotHelper/Program.cs
+++ b/src/DependabotHelper/Program.cs
@@ -80,7 +80,7 @@ builder.Logging.AddTelemetry();
 
 builder.WebHost.ConfigureKestrel((p) => p.AddServerHeader = false);
 
-builder.Services.AddAWSLambdaHosting(LambdaEventSource.RestApi);
+builder.Services.AddAWSLambdaHosting(LambdaEventSource.RestApi, new ApplicationLambdaSerializer());
 
 var app = builder.Build();
 


### PR DESCRIPTION
- Fix native AoT warnings that are resolvable through package upgrades.
- Bump Newtonsoft.Json transient dependency to the latest version.
- Humanizer, Octokit and Newtonsoft.Json still produce warnings, so AoT cannot be enabled yet.
