### PR TITLE
Store antiforgery token

### DIFF
--- a/src/DependabotHelper/AuthenticationEndpoints.cs
+++ b/src/DependabotHelper/AuthenticationEndpoints.cs
@@ -84,6 +84,9 @@ public static class AuthenticationEndpoints
                     context.Properties!.ExpiresUtc = timeProvider.GetUtcNow().AddDays(60);
                     context.Properties.IsPersistent = true;
 
+                    var antiforgery = context.HttpContext.RequestServices.GetRequiredService<IAntiforgery>();
+                    antiforgery.SetCookieTokenAndHeader(context.HttpContext);
+
                     return Task.CompletedTask;
                 };
             })
@@ -207,6 +210,7 @@ public static class AuthenticationEndpoints
         {
             if (!await antiforgery.IsRequestValidAsync(context))
             {
+                antiforgery.SetCookieTokenAndHeader(context);
                 return Results.Redirect(RootPath);
             }
 


### PR DESCRIPTION
- Store anti-forgery token after signing in to avoid an inability to sign out if the token is invalid (without deleting cookies).
- If the anti-forgery token is invalid, store a new one.
