### PR TITLE
Suppress IDE0130

### DIFF
--- a/src/DependabotHelper/OctokitExtensions.cs
+++ b/src/DependabotHelper/OctokitExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+#pragma warning disable IDE0130
 namespace Octokit;
 
 public static class OctokitExtensions

--- a/tests/DependabotHelper.Tests/Infrastructure/IWebHostBuilderExtensions.cs
+++ b/tests/DependabotHelper.Tests/Infrastructure/IWebHostBuilderExtensions.cs
@@ -5,6 +5,7 @@ using MartinCostello.DependabotHelper.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 
+#pragma warning disable IDE0130
 namespace Microsoft.Extensions.DependencyInjection;
 
 public static class IWebHostBuilderExtensions

--- a/tests/DependabotHelper.Tests/Infrastructure/ShouldlyTaskExtensions.cs
+++ b/tests/DependabotHelper.Tests/Infrastructure/ShouldlyTaskExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2022. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+#pragma warning disable IDE0130
 namespace Shouldly;
 
 public static class ShouldlyTaskExtensions


### PR DESCRIPTION
Suppress new IDE0130 warnings from .NET 9 preview 6.
