### PR TITLE
Skip workload manifest update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
 
     - name: Install .NET Workloads
       shell: pwsh
-      run: dotnet workload restore
+      run: dotnet workload restore --skip-manifest-update
 
     - name: Build, Test and Publish
       id: build


### PR DESCRIPTION
Skip updating .NET workload manifests to speed up CI on Windows.
