### PR TITLE
Fix fuzzy avatars

### DIFF
--- a/src/DependabotHelper/AuthenticationEndpoints.cs
+++ b/src/DependabotHelper/AuthenticationEndpoints.cs
@@ -139,7 +139,7 @@ public static class AuthenticationEndpoints
     /// The GitHub avatar URL for the current user, if any.
     /// </returns>
     public static string GetAvatarUrl(this ClaimsPrincipal user)
-        => GitHubService.ApplyMaximumAvatarSize(user.FindFirst(GitHubAvatarClaim)?.Value ?? string.Empty);
+        => user.FindFirst(GitHubAvatarClaim)?.Value ?? string.Empty;
 
     /// <summary>
     /// Gets the user's GitHub profile URL.

--- a/src/DependabotHelper/GitHubService.cs
+++ b/src/DependabotHelper/GitHubService.cs
@@ -31,16 +31,6 @@ public sealed class GitHubService(
 
     private readonly DependabotOptions _options = options.Value;
 
-    public static string ApplyMaximumAvatarSize(string url)
-    {
-        if (!string.IsNullOrEmpty(url))
-        {
-            url += "&size=32";
-        }
-
-        return url;
-    }
-
     public async Task ApprovePullRequestAsync(string owner, string name, int number)
     {
         logger.LogInformation(
@@ -88,7 +78,7 @@ public sealed class GitHubService(
         {
             owners.Add(new()
             {
-                AvatarUrl = ApplyMaximumAvatarSize(organization.AvatarUrl),
+                AvatarUrl = organization.AvatarUrl,
                 Name = organization.Login,
             });
         }

--- a/src/DependabotHelper/styles/main.css
+++ b/src/DependabotHelper/styles/main.css
@@ -25,7 +25,7 @@ html {
 }
 
 a {
-    color: #0060C7;
+    color: #0060c7;
     text-decoration: none;
 }
 
@@ -46,8 +46,8 @@ img {
 }
 
 img.user-profile {
-    max-height: 30px;
-    max-width: 30px;
+    max-height: 2rem;
+    max-width: 2rem;
 }
 
 /*
@@ -161,7 +161,7 @@ tr.table-inactive > td span[aria-hidden="true"].repo-status {
 }
 
 .navbar-dark .navbar-nav .nav-link {
-    color: #B0B0B0;
+    color: #b0b0b0;
 }
 
 .pr-title::after {


### PR DESCRIPTION
- Fix fuzzy avatar images by constraining the size with CSS, rather than with a query string.
- Use `rem` to specify the avatar sizes, rather than pixels.
- Lowercase hex colours.
