### PR TITLE
Bump NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.6" />
+    <GlobalPackageReference Include="ReferenceTrimmer" Version="3.3.10" />
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
@@ -42,7 +42,7 @@
     <PackageVersion Include="Polly.Extensions" Version="8.4.2" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.4.2" />
     <PackageVersion Include="RazorSlices" Version="0.8.1" />
-    <PackageVersion Include="ReportGenerator" Version="5.3.9" />
+    <PackageVersion Include="ReportGenerator" Version="5.3.10" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.8" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0-rc.1.24431.7" />

--- a/src/DependabotHelper/scripts/View/App.test.ts
+++ b/src/DependabotHelper/scripts/View/App.test.ts
@@ -23,7 +23,6 @@ describe('App', () => {
     });
 
     describe('for pull requests', () => {
-
         beforeEach(() => {
             /* eslint-disable max-len */
             document.body.innerHTML = `
@@ -239,7 +238,6 @@ describe('App', () => {
     });
 
     describe('for configuring repositories', () => {
-
         beforeEach(() => {
             /* eslint-disable max-len */
             document.body.innerHTML = `


### PR DESCRIPTION
Update NuGet packages while dependabot doesn't support .NET 9.
