### PR TITLE
Disable some Lighthouse audits

### DIFF
--- a/.github/lighthouse.config.json
+++ b/.github/lighthouse.config.json
@@ -1,0 +1,12 @@
+{
+  "config": {
+    "settings": {
+      "skipAudits": [
+        "render-blocking-resources",
+        "unused-css-rules",
+        "unused-javascript",
+        "uses-text-compression"
+      ]
+    }
+  }
+}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -69,8 +69,9 @@ jobs:
         device: 'all'
         gitHubAccessToken: ${{ secrets.LIGHTHOUSE_ACCESS_TOKEN }}
         outputDirectory: ${{ github.workspace }}/artifacts/lighthouse
+        overridesJsonFile: ./.github/lighthouse.config.json
         prCommentEnabled: true
-        urls: ${{ env.APPLICATION_URL }}
+        urls: '${{ env.APPLICATION_URL }}/sign-in'
         wait: true
 
     - name: Check Lighthouse scores

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -78,8 +78,8 @@ jobs:
       uses: foo-software/lighthouse-check-status-action@2b9d5101f7a0de86ddb153a0d77ad7046aac1052 # v3.0.1
       with:
         lighthouseCheckResults: ${{ steps.lighthouse.outputs.lighthouseCheckResults }}
-        minAccessibilityScore: "95"
-        minBestPracticesScore: "92"
+        minAccessibilityScore: "100"
+        minBestPracticesScore: "100"
         minPerformanceScore: "95"
         minProgressiveWebAppScore: "50"
         minSeoScore: "60"

--- a/src/DependabotHelper/Slices/_Layout.cshtml
+++ b/src/DependabotHelper/Slices/_Layout.cshtml
@@ -244,7 +244,7 @@
         </footer>
     </main>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" integrity="sha512-7Pi/otdlbbCR+LnW+F7PwFcSDJOuUJB3OxtEHbg4vSMvzvJjde4Po1v4BR9Gdc9aXNUNFVUY+SK51wWT8WF0Gg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="@(HttpContext.Content("~/static/js/main.js"))"></script>
+    <script src="@(HttpContext.Content("~/static/js/main.js"))" defer></script>
 </body>
 <!--
     Deployment:    @(build)


### PR DESCRIPTION
- Disable various audits in Lighthouse for third-party resources.
- Defer JavaScript loading.
- Avoid Lighthouse redirect.
