### PR TITLE
Consume .NET nightly builds

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="JustEat.HttpClientInterception" Version="5.1.1" />
     <PackageVersion Include="MartinCostello.Logging.XUnit.v3" Version="0.5.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0-preview.2.25164.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0-preview.4.25208.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.51.0" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,7 @@
     <clear />
     <add key="aspnet-contrib" value="https://www.myget.org/F/aspnet-contrib/api/v3/index.json" />
     <add key="benchmarkdotnet" value="https://www.myget.org/F/benchmarkdotnet/api/v3/index.json" />
+    <add key="dotnet10" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json" />
     <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
@@ -13,6 +14,9 @@
     <packageSource key="benchmarkdotnet">
       <package pattern="BenchmarkDotNet" />
       <package pattern="BenchmarkDotNet.*" />
+    </packageSource>
+    <packageSource key="dotnet10">
+      <package pattern="*" />
     </packageSource>
     <packageSource key="NuGet">
       <package pattern="*" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100-preview.2.25164.34",
+    "version": "10.0.100-preview.4.25208.36",
     "allowPrerelease": false,
     "rollForward": "latestMajor",
     "paths": [ ".dotnet", "$host$" ],


### PR DESCRIPTION
Update to the latest nightly build of .NET 10.