### PR TITLE
Use repository dispatch for annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,50 +239,35 @@ jobs:
       url: ${{ env.APPLICATION_URL_PROD }}
 
     permissions:
+      contents: write
       id-token: write
 
     steps:
 
     - name: Create deployment annotation
-      id: annotate-deployment
-      shell: pwsh
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       env:
         APPLICATION_NAME: ${{ env.AZURE_WEBAPP_NAME }}
         ENVIRONMENT_NAME: production
-        TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}
-        TELEMETRY_URL: ${{ vars.TELEMETRY_URL }}
-      run: |
-        $commitSha = ${env:GITHUB_SHA}.Substring(0, 7)
-        $commitUrl = "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/commit/${env:GITHUB_SHA}"
-        $workflowUrl = "${env:GITHUB_SERVER_URL}/${env:GITHUB_REPOSITORY}/actions/runs/${env:GITHUB_RUN_ID}"
-
-        $body = @{
-          tags = @(
-            "deployment",
-            "environment:${env:ENVIRONMENT_NAME}",
-            "service:${env:APPLICATION_NAME}"
-          );
-          text = "Deployed <a href='${workflowUrl}'>#${env:GITHUB_RUN_NUMBER}:${env:GITHUB_RUN_ATTEMPT}</a> with commit <a href='${commitUrl}'>${commitSha}</a>";
-          time = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds();
-        } | ConvertTo-Json
-
-        try {
-          $annotation = Invoke-RestMethod -Uri "${env:TELEMETRY_URL}/api/annotations" `
-            -Method Post `
-            -Headers @{
-              "Accept" = "application/json";
-              "Authorization" = "Bearer ${env:TELEMETRY_TOKEN}";
-              "Content-Type" = "application/json";
-            } `
-            -Body $body
-
-          $id = $annotation.id
-
-          Write-Output "Created deployment annotation ${id}"
-          "id=${id}" >> ${env:GITHUB_OUTPUT}
-        } catch {
-          Write-Output "::warning::Failed to create deployment annotation"
-        }
+      with:
+        script: |
+          const { repo, owner } = context.repo;
+          await github.rest.repos.createDispatchEvent({
+            owner,
+            repo,
+            event_type: 'deployment_started',
+            client_payload: {
+              application: process.env.APPLICATION_NAME,
+              environment: process.env.ENVIRONMENT_NAME,
+              repository: process.env.GITHUB_REPOSITORY,
+              runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+              runId: process.env.GITHUB_RUN_ID,
+              runNumber: process.env.GITHUB_RUN_NUMBER,
+              serverUrl: process.env.GITHUB_SERVER_URL,
+              sha: process.env.GITHUB_SHA,
+              timestamp: Date.now(),
+            }
+          });
 
     - name: Azure log in
       uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -327,31 +312,22 @@ jobs:
         }
 
     - name: Update deployment annotation
-      if: ${{ !cancelled() && steps.annotate-deployment.outputs.id != '' }}
-      shell: pwsh
-      env:
-        ANNOTATION_ID: ${{ steps.annotate-deployment.outputs.id }}
-        TELEMETRY_TOKEN: ${{ secrets.TELEMETRY_TOKEN }}
-        TELEMETRY_URL: ${{ vars.TELEMETRY_URL }}
-      run: |
-        $body = @{
-          timeEnd = [DateTimeOffset]::UtcNow.ToUnixTimeMilliseconds();
-        } | ConvertTo-Json
-
-        try {
-          Invoke-RestMethod -Uri "${env:TELEMETRY_URL}/api/annotations/${env:ANNOTATION_ID}" `
-            -Method Patch `
-            -Headers @{
-              "Accept" = "application/json";
-              "Authorization" = "Bearer ${env:TELEMETRY_TOKEN}";
-              "Content-Type" = "application/json";
-            } `
-            -Body $body | Out-Null
-
-          Write-Output "Updated deployment annotation ${env:ANNOTATION_ID}"
-        } catch {
-          Write-Output "::warning::Failed to update deployment annotation ${env:ANNOTATION_ID}"
-        }
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      if: ${{ !cancelled() }}
+      with:
+        script: |
+          const { repo, owner } = context.repo;
+          await github.rest.repos.createDispatchEvent({
+            owner,
+            repo,
+            event_type: 'deployment_completed',
+            client_payload: {
+              repository: process.env.GITHUB_REPOSITORY,
+              runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+              runNumber: process.env.GITHUB_RUN_NUMBER,
+              timestamp: Date.now(),
+            }
+          });
 
   test:
     name: test-production


### PR DESCRIPTION
Simplify deployment annotations by using `repository_dispatch` to delegate creation.
