### PR TITLE
Enable PKCE for GitHub OAuth

### DIFF
--- a/src/DependabotHelper/AuthenticationEndpoints.cs
+++ b/src/DependabotHelper/AuthenticationEndpoints.cs
@@ -63,6 +63,7 @@ public static class AuthenticationEndpoints
                 options.CorrelationCookie.Name = CookiePrefix + "correlation";
                 options.EnterpriseDomain = configuration.Value.EnterpriseDomain;
                 options.SaveTokens = true;
+                options.UsePkce = true;
 
                 foreach (string scope in configuration.Value.Scopes)
                 {


### PR DESCRIPTION
Enable use of PKCE when signing in with GitHub OAuth.

See [_PKCE support for OAuth and GitHub App authentication_](https://github.blog/changelog/2025-07-14-pkce-support-for-oauth-and-github-app-authentication/).
