### PR TITLE
Update licenses

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Review dependencies
         uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
-          allow-licenses: '(MIT AND BSD-3-Clause),(MIT AND Zlib),(MIT OR Apache-2.0),(MIT OR CC0-1.0),0BSD,Apache-2.0,BlueOak-1.0.0,BSD-2-Clause,BSD-3-Clause,CC-BY-4.0,CC0-1.0,ISC,MIT,MIT-0,Python-2.0'
+          allow-licenses: '(MIT AND BSD-3-Clause),(MIT AND Zlib),(MIT OR Apache-2.0),(MIT OR CC0-1.0),0BSD,Apache-2.0,BlueOak-1.0.0,BSD-2-Clause,BSD-3-Clause,CC-BY-4.0,CC0-1.0,ISC,MIT,MIT-0,Python-2.0,LicenseRef-scancode-generic-cla AND MIT,LicenseRef-scancode-ms-typescript-msbuild-4.1.4,	LicenseRef-scancode-ms-web-developer-tools-1.0 AND LicenseRef-scancode-ms-sql-server-compact-4.0 AND MIT

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Review dependencies
         uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
-          allow-licenses: '(MIT AND BSD-3-Clause),(MIT AND Zlib),(MIT OR Apache-2.0),(MIT OR CC0-1.0),0BSD,Apache-2.0,BlueOak-1.0.0,BSD-2-Clause,BSD-3-Clause,CC-BY-4.0,CC0-1.0,ISC,MIT,MIT-0,Python-2.0,LicenseRef-scancode-generic-cla AND MIT,LicenseRef-scancode-ms-typescript-msbuild-4.1.4,LicenseRef-scancode-ms-web-developer-tools-1.0 AND LicenseRef-scancode-ms-sql-server-compact-4.0 AND MIT
+          allow-licenses: '(MIT AND BSD-3-Clause),(MIT AND Zlib),(MIT OR Apache-2.0),(MIT OR CC0-1.0),0BSD,Apache-2.0,BlueOak-1.0.0,BSD-2-Clause,BSD-3-Clause,CC-BY-4.0,CC0-1.0,ISC,MIT,MIT-0,Python-2.0,LicenseRef-scancode-generic-cla AND MIT,LicenseRef-scancode-ms-typescript-msbuild-4.1.4,LicenseRef-scancode-ms-web-developer-tools-1.0 AND LicenseRef-scancode-ms-sql-server-compact-4.0 AND MIT'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Review dependencies
         uses: actions/dependency-review-action@da24556b548a50705dd671f47852072ea4c105d9 # v4.7.1
         with:
-          allow-licenses: '(MIT AND BSD-3-Clause),(MIT AND Zlib),(MIT OR Apache-2.0),(MIT OR CC0-1.0),0BSD,Apache-2.0,BlueOak-1.0.0,BSD-2-Clause,BSD-3-Clause,CC-BY-4.0,CC0-1.0,ISC,MIT,MIT-0,Python-2.0,LicenseRef-scancode-generic-cla AND MIT,LicenseRef-scancode-ms-typescript-msbuild-4.1.4,	LicenseRef-scancode-ms-web-developer-tools-1.0 AND LicenseRef-scancode-ms-sql-server-compact-4.0 AND MIT
+          allow-licenses: '(MIT AND BSD-3-Clause),(MIT AND Zlib),(MIT OR Apache-2.0),(MIT OR CC0-1.0),0BSD,Apache-2.0,BlueOak-1.0.0,BSD-2-Clause,BSD-3-Clause,CC-BY-4.0,CC0-1.0,ISC,MIT,MIT-0,Python-2.0,LicenseRef-scancode-generic-cla AND MIT,LicenseRef-scancode-ms-typescript-msbuild-4.1.4,LicenseRef-scancode-ms-web-developer-tools-1.0 AND LicenseRef-scancode-ms-sql-server-compact-4.0 AND MIT


### PR DESCRIPTION
Update the allowed licenses to include Azure, Aspire and TypeScript NuGet packages.

Discovered through #2296 and [Automatic dependency submission](https://docs.github.com/code-security/supply-chain-security/understanding-your-software-supply-chain/configuring-automatic-dependency-submission-for-your-repository) being enabled.